### PR TITLE
fix: missing file extension for csv file exports

### DIFF
--- a/staff_graded/__init__.py
+++ b/staff_graded/__init__.py
@@ -2,4 +2,4 @@
 
 from .staff_graded import StaffGradedXBlock
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/staff_graded/staff_graded.py
+++ b/staff_graded/staff_graded.py
@@ -237,7 +237,7 @@ class StaffGradedXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             cohort=cohort).write_file(buf)
         resp = Response(buf.getvalue())
         resp.content_type = 'text/csv'
-        resp.content_disposition = f'attachment; filename="{self.location}"'
+        resp.content_disposition = f'attachment; filename="{self.location}.csv"'
         return resp
 
     @XBlock.handler


### PR DESCRIPTION
bug introduced here:
https://github.com/openedx/staff_graded-xblock/commit/596395f19f35f2008c66a6c4a70ab9ad5dd3af68#diff-a003fecb848b3ae19a4084d178ca77a95229f2c7b091bc490ade8bc8eb99570aL240 fyi @aht007 

[JIRA:TNL-9720](https://openedx.atlassian.net/browse/TNL-9720)