### PR TITLE
build: remove unnecessary codecov dependency

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,5 +3,4 @@
 
 -r tox.txt
 
-codecov
 six

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.5.18.1
     # via requests
 charset-normalizer==2.0.12
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==6.4.1
     # via codecov
 distlib==0.3.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -70,8 +70,6 @@ click-repl==0.2.0
     #   celery
 code-annotations==1.3.0
     # via edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage[toml]==6.2
     # via
     #   codecov


### PR DESCRIPTION
Context: https://about.codecov.io/blog/message-regarding-the-pypi-package/
