### PR TITLE
chore: remove web-fragments dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,5 +4,4 @@
 edx-bulk-grades
 markdown
 path.py
-web-fragments
 XBlock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,15 +12,15 @@ asgiref==3.11.1
     # via django
 billiard==4.2.4
     # via celery
-celery==5.6.2
+celery==5.6.3
     # via edx-celeryutils
-certifi==2026.2.25
+certifi==2026.5.20
     # via requests
 cffi==2.0.0
     # via pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.4.1
     # via
     #   celery
     #   click-didyoumean
@@ -33,7 +33,7 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-django==5.2.12
+django==5.2.15
     # via
     #   -c requirements/common_constraints.txt
     #   django-crum
@@ -56,29 +56,31 @@ django-model-utils==5.0.0
     #   super-csv
 django-waffle==5.0.0
     # via edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via super-csv
 dnspython==2.8.0
     # via pymongo
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via -r requirements/base.in
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via super-csv
 edx-django-utils==8.0.1
     # via super-csv
-edx-opaque-keys==3.1.0
-    # via edx-bulk-grades
+edx-opaque-keys==4.0.0
+    # via
+    #   edx-bulk-grades
+    #   xblock
 fs==2.4.16
     # via xblock
-idna==3.11
+idna==3.18
     # via requests
 jsonfield==3.2.0
     # via edx-celeryutils
 kombu==5.6.2
     # via celery
-lxml==6.0.2
+lxml==6.1.1
     # via xblock
-mako==1.3.10
+mako==1.3.12
     # via xblock
 markdown==3.10.2
     # via -r requirements/base.in
@@ -86,7 +88,7 @@ markupsafe==3.0.3
     # via
     #   mako
     #   xblock
-packaging==26.0
+packaging==26.2
     # via kombu
 path==17.1.1
     # via path-py
@@ -98,7 +100,7 @@ psutil==7.2.2
     # via edx-django-utils
 pycparser==3.0
     # via cffi
-pymongo==4.16.0
+pymongo==4.17.0
     # via edx-opaque-keys
 pynacl==1.6.2
     # via edx-django-utils
@@ -106,15 +108,15 @@ python-dateutil==2.9.0.post0
     # via
     #   celery
     #   xblock
-pytz==2026.1.post1
+pytz==2026.2
     # via xblock
 pyyaml==6.0.3
     # via xblock
-requests==2.32.5
+requests==2.34.2
     # via
     #   edx-bulk-grades
     #   slumber
-simplejson==3.20.2
+simplejson==4.1.1
     # via
     #   super-csv
     #   xblock
@@ -126,34 +128,30 @@ slumber==0.7.1
     # via edx-bulk-grades
 sqlparse==0.5.5
     # via django
-stevedore==5.7.0
+stevedore==5.8.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via edx-bulk-grades
 typing-extensions==4.15.0
     # via edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.2
     # via kombu
 tzlocal==5.3.1
     # via celery
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via prompt-toolkit
-web-fragments==3.1.0
-    # via
-    #   -r requirements/base.in
-    #   xblock
-webob==1.8.9
+webob==1.8.10
     # via xblock
-xblock==5.3.0
+xblock==6.2.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==7.0.3
+cachetools==7.1.4
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -12,22 +12,22 @@ colorama==0.4.6
     # via
     #   -r requirements/tox.txt
     #   tox
-distlib==0.4.0
+distlib==0.4.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.25.0
+filelock==3.29.3
     # via
     #   -r requirements/tox.txt
     #   python-discovery
     #   tox
     #   virtualenv
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/tox.txt
     #   pyproject-api
     #   tox
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   -r requirements/tox.txt
     #   python-discovery
@@ -37,13 +37,14 @@ pluggy==1.6.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via
     #   -r requirements/tox.txt
     #   tox
-python-discovery==1.1.1
+python-discovery==1.4.2
     # via
     #   -r requirements/tox.txt
+    #   tox
     #   virtualenv
 six==1.17.0
     # via -r requirements/ci.in
@@ -51,9 +52,9 @@ tomli-w==1.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==4.49.0
+tox==4.55.1
     # via -r requirements/tox.txt
-virtualenv==21.1.0
+virtualenv==21.4.3
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,17 +24,17 @@ billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-build==1.4.0
+build==1.5.0
     # via pip-tools
-cachetools==7.0.3
+cachetools==7.1.4
     # via
     #   -r requirements/tox.txt
     #   tox
-celery==5.6.2
+celery==5.6.3
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.5.20
     # via
     #   -r requirements/base.txt
     #   requests
@@ -42,11 +42,11 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.1
+click==8.4.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -72,21 +72,21 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via edx-lint
 colorama==0.4.6
     # via
     #   -r requirements/tox.txt
     #   tox
-coverage[toml]==7.13.4
+coverage[toml]==7.14.1
     # via pytest-cov
 dill==0.4.1
     # via pylint
-distlib==0.4.0
+distlib==0.4.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-django==5.2.12
+django==5.2.15
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -115,7 +115,7 @@ django-model-utils==5.0.0
     #   edx-bulk-grades
     #   edx-celeryutils
     #   super-csv
-django-statici18n==2.6.0
+django-statici18n==2.7.1
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.in
@@ -123,7 +123,7 @@ django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/base.txt
     #   super-csv
@@ -131,11 +131,11 @@ dnspython==2.8.0
     # via
     #   -r requirements/base.txt
     #   pymongo
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via
     #   -r requirements/base.in
     #   -r requirements/base.txt
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via
     #   -r requirements/base.txt
     #   super-csv
@@ -145,13 +145,14 @@ edx-django-utils==8.0.1
     #   super-csv
 edx-i18n-tools==1.6.1
     # via -r requirements/dev.in
-edx-lint==5.6.0
+edx-lint==6.1.0
     # via -r requirements/test.in
-edx-opaque-keys==3.1.0
+edx-opaque-keys==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-bulk-grades
-filelock==3.25.0
+    #   xblock
+filelock==3.29.3
     # via
     #   -r requirements/tox.txt
     #   python-discovery
@@ -161,7 +162,7 @@ fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   xblock
-idna==3.11
+idna==3.18
     # via
     #   -r requirements/base.txt
     #   requests
@@ -179,15 +180,15 @@ kombu==5.6.2
     # via
     #   -r requirements/base.txt
     #   celery
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.1.1
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
-lxml-html-clean==0.4.4
+lxml-html-clean==0.4.5
     # via lxml
-mako==1.3.10
+mako==1.3.12
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -203,7 +204,7 @@ markupsafe==3.0.3
     #   xblock
 mccabe==0.7.0
     # via pylint
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/tox.txt
@@ -224,7 +225,7 @@ path-py==12.5.0
     #   -r requirements/base.txt
 pip-tools==7.5.3
     # via -r requirements/pip_tools.in
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   -r requirements/tox.txt
     #   pylint
@@ -251,7 +252,7 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pylint==4.0.5
     # via
@@ -267,7 +268,7 @@ pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -275,7 +276,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -283,22 +284,23 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via pytest-cov
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   celery
     #   xblock
-python-discovery==1.1.1
+python-discovery==1.4.2
     # via
     #   -r requirements/tox.txt
+    #   tox
     #   virtualenv
 python-slugify==8.0.4
     # via code-annotations
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -308,12 +310,12 @@ pyyaml==6.0.3
     #   code-annotations
     #   edx-i18n-tools
     #   xblock
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   edx-bulk-grades
     #   slumber
-simplejson==3.20.2
+simplejson==4.1.1
     # via
     #   -r requirements/base.txt
     #   super-csv
@@ -333,13 +335,13 @@ sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.7.0
+stevedore==5.8.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-bulk-grades
@@ -349,9 +351,11 @@ tomli-w==1.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
-tomlkit==0.14.0
-    # via pylint
-tox==4.49.0
+tomlkit==0.15.0
+    # via
+    #   edx-lint
+    #   pylint
+tox==4.55.1
     # via
     #   -r requirements/tox.in
     #   -r requirements/tox.txt
@@ -359,7 +363,7 @@ typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -367,7 +371,7 @@ tzlocal==5.3.1
     # via
     #   -r requirements/base.txt
     #   celery
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -377,26 +381,21 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.1.0
+virtualenv==21.4.3
     # via
     #   -r requirements/tox.txt
     #   tox
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
-web-fragments==3.1.0
-    # via
-    #   -r requirements/base.in
-    #   -r requirements/base.txt
-    #   xblock
-webob==1.8.9
+webob==1.8.10
     # via
     #   -r requirements/base.txt
     #   xblock
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
-xblock==5.3.0
+xblock==6.2.0
     # via
     #   -r requirements/base.in
     #   -r requirements/base.txt

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-build==1.4.0
+build==1.5.0
     # via pip-tools
-click==8.3.1
+click==8.4.1
     # via pip-tools
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   wheel
@@ -18,11 +18,11 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1.2
     # via pip-tools
-setuptools==82.0.0
+setuptools==82.0.1
     # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,11 +24,11 @@ billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.6.2
+celery==5.6.3
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.5.20
     # via
     #   -r requirements/base.txt
     #   requests
@@ -36,11 +36,11 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.1
+click==8.4.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -65,9 +65,9 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via edx-lint
-coverage[toml]==7.13.4
+coverage[toml]==7.14.1
     # via pytest-cov
 dill==0.4.1
     # via pylint
@@ -98,13 +98,13 @@ django-model-utils==5.0.0
     #   edx-bulk-grades
     #   edx-celeryutils
     #   super-csv
-django-statici18n==2.6.0
+django-statici18n==2.7.1
     # via -r requirements/test.in
 django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
     #   -r requirements/base.txt
     #   super-csv
@@ -112,9 +112,9 @@ dnspython==2.8.0
     # via
     #   -r requirements/base.txt
     #   pymongo
-edx-bulk-grades==1.2.0
+edx-bulk-grades==2.0.0
     # via -r requirements/base.txt
-edx-celeryutils==1.4.0
+edx-celeryutils==2.0.0
     # via
     #   -r requirements/base.txt
     #   super-csv
@@ -122,17 +122,18 @@ edx-django-utils==8.0.1
     # via
     #   -r requirements/base.txt
     #   super-csv
-edx-lint==5.6.0
+edx-lint==6.1.0
     # via -r requirements/test.in
-edx-opaque-keys==3.1.0
+edx-opaque-keys==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-bulk-grades
+    #   xblock
 fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   xblock
-idna==3.11
+idna==3.18
     # via
     #   -r requirements/base.txt
     #   requests
@@ -150,11 +151,11 @@ kombu==5.6.2
     # via
     #   -r requirements/base.txt
     #   celery
-lxml==6.0.2
+lxml==6.1.1
     # via
     #   -r requirements/base.txt
     #   xblock
-mako==1.3.10
+mako==1.3.12
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -168,7 +169,7 @@ markupsafe==3.0.3
     #   xblock
 mccabe==0.7.0
     # via pylint
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -179,7 +180,7 @@ path==17.1.1
     #   path-py
 path-py==12.5.0
     # via -r requirements/base.txt
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via pylint
 pluggy==1.6.0
     # via
@@ -197,7 +198,7 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pylint==4.0.5
     # via
@@ -213,7 +214,7 @@ pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -221,9 +222,9 @@ pynacl==1.6.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==9.0.2
+pytest==9.0.3
     # via pytest-cov
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
@@ -232,7 +233,7 @@ python-dateutil==2.9.0.post0
     #   xblock
 python-slugify==8.0.4
     # via code-annotations
-pytz==2026.1.post1
+pytz==2026.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -241,12 +242,12 @@ pyyaml==6.0.3
     #   -r requirements/base.txt
     #   code-annotations
     #   xblock
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   edx-bulk-grades
     #   slumber
-simplejson==3.20.2
+simplejson==4.1.1
     # via
     #   -r requirements/base.txt
     #   super-csv
@@ -265,25 +266,27 @@ sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.7.0
+stevedore==5.8.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==4.1.0
+super-csv==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-bulk-grades
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.14.0
-    # via pylint
+tomlkit==0.15.0
+    # via
+    #   edx-lint
+    #   pylint
 typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -291,7 +294,7 @@ tzlocal==5.3.1
     # via
     #   -r requirements/base.txt
     #   celery
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -301,19 +304,15 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
-web-fragments==3.1.0
+webob==1.8.10
     # via
     #   -r requirements/base.txt
     #   xblock
-webob==1.8.9
-    # via
-    #   -r requirements/base.txt
-    #   xblock
-xblock==5.3.0
+xblock==6.2.0
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,35 +4,37 @@
 #
 #    make upgrade
 #
-cachetools==7.0.3
+cachetools==7.1.4
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.4.0
+distlib==0.4.2
     # via virtualenv
-filelock==3.25.0
+filelock==3.29.3
     # via
     #   python-discovery
     #   tox
     #   virtualenv
-packaging==26.0
+packaging==26.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via tox
-python-discovery==1.1.1
-    # via virtualenv
+python-discovery==1.4.2
+    # via
+    #   tox
+    #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.55.1
     # via -r requirements/tox.in
-virtualenv==21.1.0
+virtualenv==21.4.3
     # via tox


### PR DESCRIPTION
Removes web-fragments as a dependency now that it's part of XBlock's packaging and will no longer be maintained as a separate PyPi package.

Also upgrades packages.